### PR TITLE
Fix web issue where multiple devices generated identical UUID

### DIFF
--- a/lib/web/browser_finger_print.dart
+++ b/lib/web/browser_finger_print.dart
@@ -1,0 +1,29 @@
+import 'dart:js_interop';
+
+import 'package:unique_device_identifier/web/interops/navigator_interop.dart';
+import 'package:unique_device_identifier/web/interops/screen_interop.dart';
+
+class BrowserFingerprint {
+  Future<String> collect() async {
+    final List<String> components = [
+      navigator.userAgent,
+      navigator.platform,
+      navigator.languages.toDart.join(','),
+      _getSafeNumber(navigator.hardwareConcurrency),
+      _getSafeNumber(navigator.deviceMemory),
+      _getSafeNumber(navigator.maxTouchPoints),
+      _getSafeNumber(screen.width),
+      _getSafeNumber(screen.height),
+      _getSafeNumber(screen.colorDepth),
+      DateTime.now().timeZoneName,
+    ];
+
+    return components.join('|');
+  }
+
+  String _getSafeNumber(Object? value) {
+    if (value == null) return '';
+    if (value is num) return value.toInt().toString();
+    return value.toString();
+  }
+}

--- a/lib/web/interops/navigator_interop.dart
+++ b/lib/web/interops/navigator_interop.dart
@@ -13,4 +13,5 @@ extension NavigatorExtension on Navigator {
   external String get platform;
   external int get hardwareConcurrency;
   external int get maxTouchPoints;
+  external JSAny? get deviceMemory;
 }

--- a/lib/web/interops/screen_interop.dart
+++ b/lib/web/interops/screen_interop.dart
@@ -1,0 +1,14 @@
+import 'dart:js_interop';
+
+@JS('screen')
+external Screen get screen;
+
+@JS()
+@staticInterop
+class Screen {}
+
+extension ScreenExtension on Screen {
+  external int get width;
+  external int get height;
+  external int get colorDepth;
+}

--- a/lib/web/unique_device_identifier_web.dart
+++ b/lib/web/unique_device_identifier_web.dart
@@ -1,45 +1,48 @@
+import 'dart:developer' as developer;
+
 import 'dart:js_interop';
-import 'dart:typed_data';
 import 'dart:convert';
 
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:unique_device_identifier/unique_device_identifier_platform_interface.dart';
+import 'package:unique_device_identifier/web/browser_finger_print.dart';
 
-import 'navigator_interop.dart';
 import 'window_interop.dart';
 import 'uuid_util.dart';
 
 class UniqueDeviceIdentifierWeb extends UniqueDeviceIdentifierPlatform {
+  final BrowserFingerprint _browserFingerprint = BrowserFingerprint();
+
   static void registerWith(Registrar registrar) {
     UniqueDeviceIdentifierPlatform.instance = UniqueDeviceIdentifierWeb();
   }
 
   @override
   Future<String?> getUniqueIdentifier() async {
-    try {
-      final info = [
-        navigator.userAgent,
-        navigator.languages.toDart.cast<String>().join(','),
-        navigator.platform,
-        navigator.hardwareConcurrency.toString(),
-        navigator.maxTouchPoints.toString(),
-        DateTime.now().timeZoneName,
-      ].join('|');
+    const key = 'unique_device_identifier';
+    String? uniqueIdentifier = window.localStorage.getItem(key);
 
-      final data = Uint8List.fromList(utf8.encode(info));
-      final digestBuffer = await window.crypto.subtle
-          .digest('SHA-256', data.jsify() as JSObject)
-          .toDart;
+    if (uniqueIdentifier == null) {
+      try {
+        final fingerprint = await _browserFingerprint.collect();
+        final data = utf8.encode(fingerprint);
+        final digestBuffer =
+            await window.crypto.subtle.digest('SHA-256', data.toJS).toDart;
 
-      return bufferToHex(digestBuffer as JSArrayBuffer);
-    } catch (_) {
-      const key = 'unique_device_id_fallback';
-      var stored = window.localStorage.getItem(key);
-      if (stored == null) {
-        stored = generateUUID();
-        window.localStorage.setItem(key, stored);
+        uniqueIdentifier = bufferToHex(digestBuffer as JSArrayBuffer);
+      } catch (e) {
+        uniqueIdentifier = generateUUID();
+        window.localStorage.setItem(key, uniqueIdentifier);
+
+        developer.log(
+          '[unique_device_identifier] Web: Failed create uuid. (Err. $e)',
+        );
       }
-      return stored;
     }
+
+    developer.log(
+      '[unique_device_identifier] Web: unique identifier: $uniqueIdentifier',
+    );
+    return uniqueIdentifier;
   }
 }

--- a/lib/web/uuid_util.dart
+++ b/lib/web/uuid_util.dart
@@ -5,7 +5,7 @@ import 'window_interop.dart';
 
 String generateUUID() {
   final bytes = Uint8List(16);
-  window.crypto.getRandomValues(bytes.jsify() as JSObject);
+  window.crypto.getRandomValues(bytes.toJS);
 
   // RFC 4122 version 4 UUID bits
   bytes[6] = (bytes[6] & 0x0f) | 0x40;


### PR DESCRIPTION
## Summary
Resolved a bug where all devices on the web platform were generating the same UUID (00000000-0000-4000-8000-000000000000).

## Related Issue
Issue #1

## Changes
## Changes
- Fixed incorrect UUID behavior on the Web where all devices returned the same constant value
- Added web-specific UUID generation logic:
  - Attempts to generate a UUID using a browser fingerprint
  - Falls back to a randomly generated UUID using Dart if fingerprinting fails
- A randomly generated UUID is stored in `window.localStorage` only if no valid UUID exists and fingerprint-based generation fails

## Test
- Built the Flutter web app using: `flutter build web --wasm`
- Served the app locally with: `python3 -m http.server 8080` inside the `build/web` directory
- Accessed the app via `http://localhost:8080` on:
  - Chrome (Windows/macOS)
  - Firefox
- Verified that:
  - A unique UUID was generated per browser instance
  - The UUID persisted across page reloads
  - Different browsers produced different UUIDs
