### PR TITLE
Built-in Kotlin migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## 2.x.x
+## 2.1.0
 - Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.
 - Migrates to built-in Kotlin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.x.x
+- Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.
+- Migrates to built-in Kotlin
+
 ## 2.0.4
 
 - Fixed a bug on the Web platform where all devices were generating the same UUID (`00000000-0000-4000-8000-000000000000`)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,41 +1,15 @@
 group = "com.example.unique_device_identifier"
 version = "1.0-SNAPSHOT"
 
-buildscript {
-    ext.kotlin_version = "1.8.22"
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath("com.android.tools.build:gradle:8.7.0")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
 
 android {
     namespace = "com.example.unique_device_identifier"
-
     compileSdk = 35
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     sourceSets {
@@ -49,7 +23,7 @@ android {
 
     dependencies {
         testImplementation("org.jetbrains.kotlin:kotlin-test")
-        testImplementation("org.mockito:mockito-core:5.0.0")
+        testImplementation("org.mockito:mockito-core:5.20.0")
     }
 
     testOptions {
@@ -62,5 +36,11 @@ android {
                showStandardStreams = true
             }
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,1 +1,9 @@
 rootProject.name = 'unique_device_identifier'
+
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}

--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("com.android.application")
-    id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
 }
@@ -11,12 +10,8 @@ android {
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     defaultConfig {
@@ -41,4 +36,10 @@ android {
 
 flutter {
     source = "../.."
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
 }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,5 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+android.builtInKotlin=false
+android.newDsl=false

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,5 +1,6 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+# Can be switched when Flutter is ready - 3.44 is not: https://github.com/flutter/flutter/pull/185953
 android.builtInKotlin=false
 android.newDsl=false

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-all.zip

--- a/example/android/settings.gradle.kts
+++ b/example/android/settings.gradle.kts
@@ -20,6 +20,9 @@ plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "9.2.1" apply false
 
+    // AGP 9.2.1 bundles Kotlin 2.2.10, but Flutter's DependencyVersionChecker warns
+    // below KGP 2.2.20. Pin it explicitly here to silence that warning until an AGP
+    // whose bundled Kotlin is >= 2.2.20 becomes the stable baseline.
     id("org.jetbrains.kotlin.android") version "2.2.20" apply false
 }
 

--- a/example/android/settings.gradle.kts
+++ b/example/android/settings.gradle.kts
@@ -18,8 +18,9 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.7.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.22" apply false
+    id("com.android.application") version "9.2.1" apply false
+
+    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
 }
 
 include(":app")

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,8 +7,8 @@ repository: https://github.com/jonghoon023/unique_device_identifier
 issue_tracker: https://github.com/jonghoon023/unique_device_identifier/issues
 
 environment:
-  sdk: ^3.7.2
-  flutter: '>=3.3.0'
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary

Hello,

I've managed to migrate the plugin to AGP 9 after following the guide and some good old trial and error. 

I intended to make the plugin backwards compatible for older flutter versions, but  even when applying the `kotlin-android` conditionally for `AGP >= 9` and  `android.builtInKotlin==true`  I still got KGP deprecation warnings. 

In the end I chose to bump the minimal Flutter version up to prevent confusion just for a temporary hack.

## Related Issue
Issue #8 

## Changes

```
  sdk: ^3.12.0
  flutter: ">=3.44.0"
```

## Test
Example app compiles without any warnings about Kotlin and its version.

# EDIT (2026-07-01)

From my understanding, plugin is unfortunately locked to `builtInKotlin=false`, because Flutter modules and tooling are still running on old gradle([example](https://github.com/flutter/flutter/blob/stable/packages/integration_test/android/build.gradle.kts)). The changes in this MR make sure that the plugin is able to 'coexist' with newer AGP, but there is no way to truly use the built-in kotlin yet.

When Flutter enables built-in Kotlin on stable, the follow-up here should be trivial: setting `builtInKotlin=false` and dropping the KGP pin.

References: 
 - _Even though all necessary changes have been made to migrate to Built-in Kotlin, Flutter does not support actually using Built-in Kotlin because the default is still the legacy (by design)._: https://github.com/flutter/flutter/pull/185953,
 - Flutter plugin author guide: https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors
